### PR TITLE
Implement @PreAuthorize checks for ministry actions

### DIFF
--- a/src/main/java/br/com/louvor4/api/config/SecurityConfig.java
+++ b/src/main/java/br/com/louvor4/api/config/SecurityConfig.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(securedEnabled = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 public class SecurityConfig {
 
     private final SecurityFilter securityFilter;

--- a/src/main/java/br/com/louvor4/api/config/security/MinistrySecurity.java
+++ b/src/main/java/br/com/louvor4/api/config/security/MinistrySecurity.java
@@ -1,0 +1,30 @@
+package br.com.louvor4.api.config.security;
+
+import br.com.louvor4.api.models.User;
+import br.com.louvor4.api.services.MinistryService;
+import br.com.louvor4.api.services.UserService;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component("ministrySecurity")
+public class MinistrySecurity {
+
+    private final UserService userService;
+    private final MinistryService ministryService;
+
+    public MinistrySecurity(UserService userService, MinistryService ministryService) {
+        this.userService = userService;
+        this.ministryService = ministryService;
+    }
+
+    public boolean isAdmin(String username, UUID ministryId) {
+        User user = userService.findByUsername(username);
+        return ministryService.isUserMemberAdminOfMinistry(user.getId(), ministryId);
+    }
+
+    public boolean isMember(String username, UUID ministryId) {
+        User user = userService.findByUsername(username);
+        return ministryService.isUserMemberOfMinistry(user.getId(), ministryId);
+    }
+}

--- a/src/main/java/br/com/louvor4/api/controllers/MinistryController.java
+++ b/src/main/java/br/com/louvor4/api/controllers/MinistryController.java
@@ -5,6 +5,7 @@ import br.com.louvor4.api.models.User;
 import br.com.louvor4.api.models.UserMinistry;
 import br.com.louvor4.api.services.MinistryService;
 import br.com.louvor4.api.services.UserService;
+import org.springframework.security.access.prepost.PreAuthorize;
 import br.com.louvor4.api.shared.dto.*;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -50,36 +51,34 @@ public class MinistryController {
     }
 
     @GetMapping("/{ministryId}/detail")
+    @PreAuthorize("@ministrySecurity.isMember(authentication.name, #ministryId)")
     public ResponseEntity<MinistryDetailDTO> detail(@PathVariable UUID ministryId, Authentication authentication) {
 
-        if (isUserMemberOfMinistry(authentication.getName(), ministryId)) {
+        Ministry ministry = ministryService.getMinistryById(ministryId);
 
-            Ministry ministry = ministryService.getMinistryById(ministryId);
+        List<UserDetailDTO> memberDTOs = ministry.getMembers().stream()
+                .map(UserMinistry::getUser)
+                .map(userMember -> new UserDetailDTO(
+                        userMember.getId(),
+                        userMember.getFirstName(),
+                        userMember.getLastName(),
+                        userMember.getEmail(),
+                        userMember.getPhoneNumber(),
+                        userMember.getProfileImage()
+                        ))
+                .toList();
 
-            List<UserDetailDTO> memberDTOs = ministry.getMembers().stream()
-                    .map(UserMinistry::getUser)
-                    .map(userMember -> new UserDetailDTO(
-                            userMember.getId(),
-                            userMember.getFirstName(),
-                            userMember.getLastName(),
-                            userMember.getEmail(),
-                            userMember.getPhoneNumber(),
-                            userMember.getProfileImage()
-                            ))
-                    .toList();
-
-            MinistryDetailDTO ministryDTO = new MinistryDetailDTO(
-                    ministryId,
-                    ministry.getName(),
-                    ministry.getDescription(),
-                    ministry.getProfileImage(),
-                    memberDTOs);
-            return ResponseEntity.status(HttpStatus.OK).body(ministryDTO);
-        }
-        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Você não é pertence a este ministério.");
+        MinistryDetailDTO ministryDTO = new MinistryDetailDTO(
+                ministryId,
+                ministry.getName(),
+                ministry.getDescription(),
+                ministry.getProfileImage(),
+                memberDTOs);
+        return ResponseEntity.status(HttpStatus.OK).body(ministryDTO);
     }
 
     @PutMapping("/{ministryId}/update")
+    @PreAuthorize("@ministrySecurity.isAdmin(authentication.name, #ministryId)")
     public ResponseEntity<MinistryDetailDTO> update(
             @PathVariable UUID ministryId,
             @ModelAttribute("ministryUpdateDTO")
@@ -96,8 +95,7 @@ public class MinistryController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errorMessages);
         }
 
-        if (isUserMemberAdminOfMinistry(authentication.getName(), ministryId)) {
-            Ministry ministry = ministryService.updateMinistry(ministryId, ministryUpdateDTO, profileImage);
+        Ministry ministry = ministryService.updateMinistry(ministryId, ministryUpdateDTO, profileImage);
 
             List<UserDetailDTO> memberDTOs = ministry.getMembers().stream()
                     .map(UserMinistry::getUser)
@@ -118,42 +116,27 @@ public class MinistryController {
                     ministry.getProfileImage(),
                     memberDTOs);
 
-            return ResponseEntity.status(HttpStatus.CREATED).body(ministryDTO);
-        }
-        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Você não é ADMIN neste ministério.");
+        return ResponseEntity.status(HttpStatus.CREATED).body(ministryDTO);
     }
 
     @PostMapping("/{ministryId}/add-member")
+    @PreAuthorize("@ministrySecurity.isAdmin(authentication.name, #ministryId)")
     public ResponseEntity<ApiResponse<String>> associateUsertoMinistry(
             @PathVariable UUID ministryId,
             @RequestBody @Valid AddMemberRequest addMemberRequest,
             Authentication authentication
     ) {
-        if (isUserMemberAdminOfMinistry(authentication.getName(), ministryId)) {
-            User userToassociate = userService.findByEmail(addMemberRequest.email());
-            Ministry ministry = ministryService.getMinistryById(ministryId);
-            ministryService.associateUsertoMinistry(userToassociate, ministry);
+        User userToassociate = userService.findByEmail(addMemberRequest.email());
+        Ministry ministry = ministryService.getMinistryById(ministryId);
+        ministryService.associateUsertoMinistry(userToassociate, ministry);
 
-            ApiResponse<String> response = ApiResponse.<String>create()
-                    .withStatus(HttpStatus.CREATED.value())
-                    .withTitle(USER_ASSOCIATED_TITLE)
-                    .withMessage(USER_ASSOCIATED_MESSAGE)
-                    .withData("Usuário associado com sucesso");
+        ApiResponse<String> response = ApiResponse.<String>create()
+                .withStatus(HttpStatus.CREATED.value())
+                .withTitle(USER_ASSOCIATED_TITLE)
+                .withMessage(USER_ASSOCIATED_MESSAGE)
+                .withData("Usuário associado com sucesso");
 
-            return ResponseEntity.status(HttpStatus.CREATED).body(response);
-
-        }
-        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Você não é ADMIN neste ministério.");
-    }
-
-    private boolean isUserMemberOfMinistry(String username, UUID ministryId) {
-        User user = userService.findByUsername(username);
-        return ministryService.isUserMemberOfMinistry(user.getId(), ministryId);
-    }
-
-    private boolean isUserMemberAdminOfMinistry(String username, UUID ministryId) {
-        User user = userService.findByUsername(username);
-        return ministryService.isUserMemberAdminOfMinistry(user.getId(), ministryId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
 }


### PR DESCRIPTION
## Summary
- enable pre/post method security
- add `MinistrySecurity` bean with membership helpers
- use `@PreAuthorize` on ministry endpoints

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e6f16b008331879f9907dcddcb97